### PR TITLE
Fixing node-sass compilation error by upgrading gulp-sass

### DIFF
--- a/markua
+++ b/markua
@@ -1,10 +1,10 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"
 
 str=""
 NEWLINE=$'\n'
-if [ $1 == '' ]
+if [ '$1' == '' ]
 then
   # Read from std in
   while IFS='' read -r line

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-live-server": "0.0.23",
     "gulp-mocha": "^2.0.1",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^1.3.3",
+    "gulp-sass": "^2.0.0",
     "gulp-shell": "^0.4.1",
     "gulp-util": "^3.0.6",
     "mocha": "^2.2.4",


### PR DESCRIPTION

I'm using node 6.11 and npm 3.

I got this error during npm install:
```

> node-sass@2.1.1 install markua-js/node_modules/node-sass
> node scripts/install.js

Can not download file from https://raw.githubusercontent.com/sass/node-sass-binaries/v2.1.1/linux-x64-node-6.11/binding.node

> node-sass@2.1.1 postinstall markua-js/node_modules/node-sass
> node scripts/build.js

module.js:471
    throw err;
    ^

Error: Cannot find module 'markua-js/node_modules/node-sass/node_modules/pangyp/bin/node-gyp'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:389:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:504:3
Build failed
markua-js@0.0.1 markua-js

```

I tried a few versions of node and npm, but found that the error was with the old node-sass version:
https://github.com/sass/node-sass/issues/1185

I upgraded grunt-sass to the next version that allowed node-sass to go above version 3 which solved this problem.
